### PR TITLE
Fix bagging handling in RandomForest

### DIFF
--- a/RandomForest/RandomForest.py
+++ b/RandomForest/RandomForest.py
@@ -2,15 +2,20 @@ import numpy as np
 from DecisionTree import DecisionTree
 
 class RandomForest:
-    def __init__(self, n_features, n_estimators=100, tree_params=dict(max_depth=20, min_samples_split=10, bagging=True), bagging=True):
+    def __init__(self, n_features, n_estimators=100,
+                 tree_params=dict(max_depth=20, min_samples_split=10, bagging=True),
+                 bagging=True):
         self.n_estimators = n_estimators
         self.n_features = n_features
         self.tree_params = tree_params
+        self.bagging = bagging
         self.estimators = []
     
     def build_forest(self, data):
         for _ in range(self.n_estimators):
-            new_tree = DecisionTree.DecisionTree(**self.tree_params)
+            params = dict(self.tree_params)
+            params['bagging'] = self.bagging
+            new_tree = DecisionTree.DecisionTree(**params)
             new_tree.build_tree(data, self.n_features)
 
             self.estimators.append(new_tree)

--- a/tests/TestRandomForest.ipynb
+++ b/tests/TestRandomForest.ipynb
@@ -319,7 +319,7 @@
    "source": [
     "from RandomForest import RandomForest\n",
     "\n",
-    "params = dict(max_depth=20, min_samples_split=10, bagging=True)\n",
+    "params = dict(max_depth=20, min_samples_split=10)\n",
     "\n",
     "forest1 = RandomForest.RandomForest(n_features=5, n_estimators=100, tree_params=params, bagging=True)"
    ]
@@ -594,7 +594,7 @@
    ],
    "source": [
     "# My Implementation\n",
-    "params = dict(max_depth=20, min_samples_split=10, bagging=True)\n",
+    "params = dict(max_depth=20, min_samples_split=10)\n",
     "forest1 = RandomForest.RandomForest(n_features=5, n_estimators=100, tree_params=params, bagging=True)\n",
     "forest1.build_forest(data=data_np_train)\n",
     "all_train_acc = forest1.calculate_accuracy(data=data_np_test)\n",


### PR DESCRIPTION
## Summary
- record the bagging flag in `RandomForest.__init__`
- propagate the flag when creating each decision tree
- tweak notebook examples to avoid duplicate bagging flag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684453b6b990833082f002b9d9704c74